### PR TITLE
Fix typo in README git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is the source code for my blog, which is built with [Astro](https://astro.b
 ### 1. Clone the repo
 
 ```bash
-git clone https://https://github.com/izmttk/astro-mecure.git
+git clone https://github.com/izmttk/astro-mecure.git
 cd astro-mecure
 ```
 


### PR DESCRIPTION
Removed the extra https:// from the git clone command example in README.md.